### PR TITLE
Add a common method for converting string to 'ay'

### DIFF
--- a/src/tests/dbus-tests/storagedtestcase.py
+++ b/src/tests/dbus-tests/storagedtestcase.py
@@ -111,3 +111,12 @@ class StoragedTestCase(unittest.TestCase):
         """Convert a bytearray (terminated with '\0') to a string"""
 
         return ''.join(chr(x) for x in ay[:-1])
+
+    @classmethod
+    def str_to_ay(self, string):
+        """Convert a string to a bytearray (terminated with '\0')"""
+
+        string += '\0'
+
+        return dbus.Array([dbus.Byte(ord(c)) for c in string],
+                          signature=dbus.Signature('y'), variant_level=1)

--- a/src/tests/dbus-tests/test_50_block.py
+++ b/src/tests/dbus-tests/test_50_block.py
@@ -98,12 +98,9 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self._clean_format, disk)
 
         # configuration items as arrays of dbus.Byte
-        mnt = dbus.Array([dbus.Byte(ord(c)) for c in '/mnt/test\0'],
-                         signature=dbus.Signature('y'), variant_level=1)
-        fstype = dbus.Array([dbus.Byte(ord(c)) for c in 'xfs\0'],
-                            signature=dbus.Signature('y'), variant_level=1)
-        opts = dbus.Array([dbus.Byte(ord(c)) for c in 'defaults\0'],
-                          signature=dbus.Signature('y'), variant_level=1)
+        mnt = self.str_to_ay('/mnt/test')
+        fstype = self.str_to_ay('xfs')
+        opts = self.str_to_ay('defaults')
 
         # set the new configuration
         conf = dbus.Dictionary({'dir': mnt, 'type': fstype, 'opts': opts, 'freq': 0, 'passno': 0},
@@ -122,8 +119,7 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         self.assertEqual(old_conf[0][1]['freq'], 0)
 
         # update the configuration
-        new_opts = dbus.Array([dbus.Byte(ord(c)) for c in 'defaults,noauto\0'],
-                              signature=dbus.Signature('y'), variant_level=1)
+        new_opts = self.str_to_ay('defaults,noauto')
         new_conf = copy.deepcopy(old_conf)
         new_conf[0][1]['opts'] = new_opts
 
@@ -159,10 +155,8 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         self.addCleanup(self._close_luks, disk)
 
         # configuration items as arrays of dbus.Byte
-        opts = dbus.Array([dbus.Byte(ord(c)) for c in 'verify\0'],
-                          signature=dbus.Signature('y'), variant_level=1)
-        passwd = dbus.Array([dbus.Byte(ord(c)) for c in 'test\0'],
-                            signature=dbus.Signature('y'), variant_level=1)
+        opts = self.str_to_ay('verify')
+        passwd = self.str_to_ay('test')
 
         # set the new configuration
         conf = dbus.Dictionary({'passphrase-contents': passwd,
@@ -181,8 +175,7 @@ class StoragedBlockTest(storagedtestcase.StoragedTestCase):
         self.assertEqual(sec_conf[0][1]['passphrase-contents'], passwd)
 
         # update the configuration
-        new_opts = dbus.Array([dbus.Byte(ord(c)) for c in 'verify,discard\0'],
-                              signature=dbus.Signature('y'), variant_level=1)
+        new_opts = self.str_to_ay('verify,discard')
         new_conf = copy.deepcopy(sec_conf)
         new_conf[0][1]['options'] = new_opts
 

--- a/src/tests/dbus-tests/test_80_filesystem.py
+++ b/src/tests/dbus-tests/test_80_filesystem.py
@@ -147,12 +147,9 @@ class StoragedFSTestCase(storagedtestcase.StoragedTestCase):
         self.addCleanup(tmp.cleanup)
 
         # configuration items as arrays of dbus.Byte
-        mnt = dbus.Array([dbus.Byte(ord(c)) for c in '%s\0' % tmp.name],
-                         signature=dbus.Signature('y'), variant_level=1)
-        fstype = dbus.Array([dbus.Byte(ord(c)) for c in '%s\0' % self._fs_name],
-                            signature=dbus.Signature('y'), variant_level=1)
-        opts = dbus.Array([dbus.Byte(ord(c)) for c in 'ro\0'],
-                          signature=dbus.Signature('y'), variant_level=1)
+        mnt = self.str_to_ay(tmp.name)
+        fstype = self.str_to_ay(self._fs_name)
+        opts = self.str_to_ay('ro')
 
         # set the new configuration
         conf = dbus.Dictionary({'dir': mnt, 'type': fstype, 'opts': opts, 'freq': 0, 'passno': 0},


### PR DESCRIPTION
We sometimes need to specify input as an array of bytes, instead
of a string. Let's just have a common method for it and not custom
error prone implementations across multiple tests.